### PR TITLE
Add missing quote

### DIFF
--- a/shut-up.el
+++ b/shut-up.el
@@ -36,7 +36,7 @@
 
   ;; ls does not support --dired; see `dired-use-ls-dired' for more details.
   (eval-after-load "dired"
-    (setq dired-use-ls-dired nil)))
+    '(setq dired-use-ls-dired nil)))
 
 (provide 'shut-up)
 


### PR DESCRIPTION
`eval-after-load` wants its argument in quoted form.
