### PR TITLE
Handle when sink buffer is killed.

### DIFF
--- a/test/shut-up-test.el
+++ b/test/shut-up-test.el
@@ -50,10 +50,6 @@
   (message "This message shall be visible again")
   (shut-up-test-message-shown-p "This message shall be visible again"))
 
-(ert-deftest shut-up/directs-standard-output-to-sink ()
-  (shut-up
-    (should (eq shut-up-sink standard-output))))
-
 (ert-deftest shut-up/silences-princ ()
   (with-temp-buffer
     (let ((standard-output (current-buffer)))
@@ -88,6 +84,19 @@
       (with-temp-buffer
         (insert-file-contents temp-file)
         (should (string= "Silent world" (buffer-string)))))))
+
+(ert-deftest shut-up/kill-sink-buffer ()
+  (shut-up
+   (kill-buffer shut-up-sink)
+   (message "bar")
+   (should (string= (shut-up-current-output) "")))
+  (shut-up
+   (kill-buffer shut-up-sink)
+   (print "bar")
+   (should (string= (shut-up-current-output) "")))
+  (shut-up
+   (kill-buffer shut-up-sink)
+   (should (string= (shut-up-current-output) ""))))
 
 (provide 'shut-up-test)
 


### PR DESCRIPTION
@lunaryorn Do you mind take a look at this. If `standard-output` is a buffer that is killed, things get bad. I don't know why the buffer is killed in Cask, but this solved the issue.

I'm not happy with the insertion of a character to the buffer, but I don't know of any other way to solve this better. Do you?
