### PR TITLE
Improve compatibility for `message' function.

### DIFF
--- a/shut-up.el
+++ b/shut-up.el
@@ -113,8 +113,9 @@ have any affect."
                          (shut-up-insert-to-buffer char shut-up-sink)))
                       ((symbol-function 'message)
                        (lambda (fmt &rest args)
-                         (let ((text (concat (apply #'format fmt args) "\n")))
-                           (shut-up-insert-to-buffer text shut-up-sink))))
+                         (when fmt
+                           (let ((text (concat (apply #'format fmt args) "\n")))
+                            (shut-up-insert-to-buffer text shut-up-sink)))))
                       ((symbol-function 'write-region) #'shut-up-write-region)
                       ((symbol-function 'load) #'shut-up-load))
               ,@body)


### PR DESCRIPTION
This change makes silenced implementation of `message` avoid sending nil argument to `format` function. 