### PR TITLE
Don't clobber original definitions if shut-up is loaded twice

### DIFF
--- a/shut-up.el
+++ b/shut-up.el
@@ -48,7 +48,8 @@ Changes to this variable inside a `shut-up' block has no
 effect.")
 
 ;; Preserve the original definition of `write-region'
-(fset 'shut-up-write-region-original (symbol-function 'write-region))
+(unless (fboundp 'shut-up-write-region-original)
+  (fset 'shut-up-write-region-original (symbol-function 'write-region)))
 
 (defun shut-up-write-region (start end filename
                                    &optional append visit lockname mustbenew)
@@ -61,8 +62,8 @@ effect.")
   (shut-up-write-region-original start end filename
                                  append visit lockname mustbenew))
 
-
-(fset 'shut-up-load-original (symbol-function 'load))
+(unless (fboundp 'shut-up-load-original)
+  (fset 'shut-up-load-original (symbol-function 'load)))
 
 (defun shut-up-load (file &optional noerror _nomessage nosuffix must-suffix)
   "Like `load', but try to be quiet about it."


### PR DESCRIPTION
Previously, shut-up would save the original functions for message
and load whenever shut-up.el was loaded. This assumed that
shut-up.el was only loaded once, and would only be loaded when message
and load had their original values.

As a result, the following code would break:

```emacs-lisp
;; This sets `shut-up-load-original' to the original `load' function,
;; and likewise for `shut-up-write-region-original'.
(load "path/to/shut-up.el") ;; or (require 'shut-up)

(shut-up
  ;; This sets `shut-up-load-original' to `shut-up-load'.
  (load "path/to/shut-up.el")

  ;; Since `load' has been bound to `shut-up-load', this infinitely
  ;; recurses ("Variable binding depth exceeds max-specpdl-size") when
  ;; we try to call the original with `shut-up-load-original'.
  (load "path/to/shut-up.el"))
```

This causes problems with Cask (see cask/cask#367), which uses shut-up
when byte-compiling files.

Cask installs its own copy of shut-up (see the variable
cask-bootstrap-packages in cask-bootstrap.el), making this change
difficult to test.

If Cask installs a package that depends on shut-up (such as
undercover), it ends up byte-compiling shut-up.el inside a
`(shut-up ...)` form. This only occurs when cask is not run with
`--verbose`, so that was used as a workaround.

As of Emacs 26.1 (specifically emacs-mirror/emacs@50dce3c),
byte-compiled packages are reloaded, triggering this bug. Further
byte-compilation is broken. It's not clear to me why this doesn't
apply to all packages (e.g. undercover with tuareg is fine).

Ensure that we don't have side effects if shut-up is repeatedly
loaded.