### PR TITLE
Fix return value of `message`

### DIFF
--- a/shut-up.el
+++ b/shut-up.el
@@ -121,8 +121,9 @@ have any affect."
                        ((symbol-function 'message)
                         (lambda (fmt &rest args)
                           (when fmt
-                            (let ((text (concat (apply #'format fmt args) "\n")))
-                              (shut-up-insert-to-buffer text shut-up-sink)))))
+                            (let ((text (apply #'format fmt args)))
+                              (shut-up-insert-to-buffer (concat text "\n") shut-up-sink)
+                              text))))
                        ((symbol-function 'write-region) #'shut-up-write-region)
                        ((symbol-function 'load) #'shut-up-load))
                ,@body)

--- a/test/shut-up-test.el
+++ b/test/shut-up-test.el
@@ -129,6 +129,12 @@
         (should-not (s-ends-with? "foo" (shut-up-current-output)))))
     (should (string= (buffer-string) "foo"))))
 
+(ert-deftest shut-up/message-return-value ()
+  (should (equal (shut-up (message "hi"))
+                 "hi"))
+  (should (equal (shut-up (message "hi %s" "something"))
+                 "hi something")))
+
 (provide 'shut-up-test)
 
 ;;; shut-up-test.el ends here


### PR DESCRIPTION
`message` normally returns the formatted message that it displays. Before this change, `shut-up` caused `message` to return nil instead.